### PR TITLE
Fixed maven url

### DIFF
--- a/slave/Dockerfile
+++ b/slave/Dockerfile
@@ -32,7 +32,7 @@ RUN \
 
 # Maven
 RUN mkdir -p /usr/share/maven \
-  && curl -fsSL http://apache.osuosl.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+  && curl -fsSL https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
     | tar -xzC /usr/share/maven --strip-components=1 \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
 
@@ -58,4 +58,3 @@ RUN mkdir -p .m2/repository && chown -R jenkins.jenkins .m2
 VOLUME /home/jenkins/.m2/repository
 
 USER jenkins
-


### PR DESCRIPTION
Maven moved 3.3.3 to the archive, so there was an error (404 not found) when trying to run your set-up. I updated URL to maven 3.3.3 and now it is working well :) 

Cheers