### PR TITLE
Make sure cloud-slave has access to docker commands

### DIFF
--- a/images/cloud-slave/Dockerfile
+++ b/images/cloud-slave/Dockerfile
@@ -46,4 +46,3 @@ RUN curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl && \
     chmod +x /usr/local/bin/kubectl
 
-USER jenkins


### PR DESCRIPTION
Docker socket may be exposed with different GID than
the one used inside a container. Therefore if we want
to eliminate problems with access rights it is better
to run all processes inside container as root.