### PR TITLE
bzip2 added to the javascript slave

### DIFF
--- a/images/javascript-slave/Dockerfile
+++ b/images/javascript-slave/Dockerfile
@@ -5,6 +5,6 @@ USER root
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install -y nodejs && apt-get install -y bzip2 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nodejs bzip2 && rm -rf /var/lib/apt/lists/*
 
 USER jenkins

--- a/images/javascript-slave/Dockerfile
+++ b/images/javascript-slave/Dockerfile
@@ -5,6 +5,6 @@ USER root
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install -y nodejs && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nodejs && apt-get install -y bzip2 && rm -rf /var/lib/apt/lists/*
 
 USER jenkins


### PR DESCRIPTION
bzip2 is required to unpack phantomjs, which is a dependency of many libraries.