### PR TITLE
libfontconfig added to the javascript slave

### DIFF
--- a/images/javascript-slave/Dockerfile
+++ b/images/javascript-slave/Dockerfile
@@ -5,6 +5,6 @@ USER root
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install -y nodejs bzip2 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nodejs bzip2 libfontconfig && rm -rf /var/lib/apt/lists/*
 
 USER jenkins


### PR DESCRIPTION
libfontconfig is required by phantomjs to work