### PR TITLE
Downgrade ssh-slaves plugin

### DIFF
--- a/images/jenkins/plugins.txt
+++ b/images/jenkins/plugins.txt
@@ -26,7 +26,7 @@ yet-another-docker-plugin:0.2.0
 gerrit-trigger:2.33.0
 git:4.7.0
 ssh-agent:1.22
-ssh-slaves:1.31.6
+ssh-slaves:1.31.5
 token-macro:2.15
 credentials-binding:1.24
 ansicolor:0.7.5


### PR DESCRIPTION
v1.31.6 requires jenkins 2.282+ and doesn't work with 2.277.1 (current LTS)